### PR TITLE
Added keyboard detection to al_keys and device number to KbCheck

### DIFF
--- a/Task/Classes/al_keys.m
+++ b/Task/Classes/al_keys.m
@@ -21,7 +21,8 @@ classdef al_keys
         space
         enter        
         s
-        
+        kbDev
+
     end
     
     % Methods of the conditions object
@@ -48,6 +49,24 @@ classdef al_keys
             keysobj.s = 40;  
                       
         end
+
+        function keysobj = al_kbdev( keysobj )
+            
+            kbdevs = [];
+            devs = PsychHID('Devices');
+            for d = 1:numel( devs )
+                if strcmp(devs(d).usageName,'Keyboard')
+                    kbdevs(end+1) = devs(d).index;
+                end
+            end
+            if numel( kbdevs > 1 )
+              keysobj.kbDev = -1; % "merge" all keyboard in KbCheck
+            else
+              keysobj.kbDev = kbdevs;
+            end
+
+        end
+
     end
 end
 

--- a/Task/Functions/CloseScreenAndOpenAgain.m
+++ b/Task/Functions/CloseScreenAndOpenAgain.m
@@ -29,7 +29,7 @@ function window = CloseScreenAndOpenAgain(taskParam, debug, unitTest)
             Screen('DrawingFinished', taskParam.display.window.onScreen);
             t = GetSecs;
             Screen('Flip', taskParam.display.window.onScreen, t + 0.1);
-            [~, ~, keyCode] = KbCheck;
+            [~, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
             if find(keyCode) == taskParam.keys.s
                 break
             end
@@ -44,7 +44,7 @@ function window = CloseScreenAndOpenAgain(taskParam, debug, unitTest)
         WaitSecs(1);
 
         while 1
-            [ keyIsDown, ~, keyCode ] = KbCheck;
+            [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
             if keyIsDown
                 if keyCode(taskParam.keys.s)
                     break

--- a/Task/Functions/Instructions/YouCollectedTheCannonball_TryToMissIt.m
+++ b/Task/Functions/Instructions/YouCollectedTheCannonball_TryToMissIt.m
@@ -43,7 +43,7 @@ if Data.memErr <= 9
         Screen('DrawingFinished', taskParam.gParam.window.onScreen);
         t = GetSecs;
         Screen('Flip', taskParam.gParam.window.onScreen, t + 0.1);
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
                 screenIndex = screenIndex + 1;
@@ -100,7 +100,7 @@ else
         DrawFormattedText(taskParam.gParam.window.onScreen, taskParam.strings.txtPressEnter,'center', taskParam.gParam.screensize(4)*0.9, [255 255 255]);
         Screen('DrawingFinished', taskParam.gParam.window.onScreen, 1);
         Screen('Flip', taskParam.gParam.window.onScreen, t + 1.6);
-        [ keyIsDown, ~, keyCode] = KbCheck;
+        [ keyIsDown, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
                 screenIndex = screenIndex + 1;

--- a/Task/Functions/Instructions/YouDidNotCollectTheCannonBall_TryAgain.m
+++ b/Task/Functions/Instructions/YouDidNotCollectTheCannonBall_TryAgain.m
@@ -47,7 +47,7 @@ if Data.memErr >=9
         DrawFormattedText(taskParam.gParam.window.onScreen,txt, taskParam.gParam.screensize(3)*0.1, taskParam.gParam.screensize(4)*0.05, [255 255 255], taskParam.gParam.sentenceLength);
         Screen('DrawingFinished',taskParam.gParam.window.onScreen);
         Screen('Flip', taskParam.gParam.window.onScreen, t + 1.5);
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
                 screenIndex = screenIndex - 1 ;
@@ -90,7 +90,7 @@ else
         DrawFormattedText(taskParam.gParam.window.onScreen, taskParam.strings.txtPressEnter,'center', taskParam.gParam.screensize(4)*0.9, [255 255 255]);
         Screen('DrawingFinished', taskParam.gParam.window.onScreen, 1);
         Screen('Flip', taskParam.gParam.window.onScreen, t + 1.6);
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
                 screenIndex = screenIndex + 1;

--- a/Task/Functions/Instructions/YouMissedTheCannonball_TryToCollectIt.m
+++ b/Task/Functions/Instructions/YouMissedTheCannonball_TryToCollectIt.m
@@ -76,7 +76,7 @@ function [screenIndex, Data] = YouMissedTheCannonball_TryToCollectIt(taskParam, 
             DrawFormattedText(taskParam.gParam.window.onScreen, taskParam.strings.txtPressEnter,'center', taskParam.gParam.screensize(4)*0.9, [255 255 255]);
             Screen('DrawingFinished', taskParam.gParam.window.onScreen, 1);
             Screen('Flip', taskParam.gParam.window.onScreen, t + 1.6);
-            [ keyIsDown, ~, keyCode ] = KbCheck;
+            [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
             if keyIsDown
                 if keyCode(taskParam.keys.enter)
                     screenIndex = screenIndex + 1;
@@ -114,7 +114,7 @@ function [screenIndex, Data] = YouMissedTheCannonball_TryToCollectIt(taskParam, 
             Screen('DrawingFinished',taskParam.gParam.window.onScreen);
             t = GetSecs;
             Screen('Flip', taskParam.gParam.window.onScreen, t + 0.1);
-            [ keyIsDown, ~, keyCode ] = KbCheck;
+            [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
             if keyIsDown
                 if keyCode(taskParam.keys.enter)
                     screenIndex = screenIndex - 2;

--- a/Task/Functions/Instructions/al_confirmMiss.m
+++ b/Task/Functions/Instructions/al_confirmMiss.m
@@ -82,7 +82,7 @@ while 1
     Screen('Flip', taskParam.display.window.onScreen, tUpdated + 1.2);
     
     % Terminate when subject presses enter
-    [keyIsDown, ~, keyCode] = KbCheck;
+    [keyIsDown, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
     if keyIsDown
         if keyCode(taskParam.keys.enter)
             break

--- a/Task/Functions/Instructions/al_indicateCondition.m
+++ b/Task/Functions/Instructions/al_indicateCondition.m
@@ -22,7 +22,7 @@ while 1
     Screen('Flip', taskParam.display.window.onScreen, t + 0.1);
 
     % Wait for button press
-    [~, ~, keyCode] = KbCheck;
+    [~, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
     if find(keyCode) == taskParam.keys.enter
         break
     end

--- a/Task/Functions/Instructions/al_introduceShield.m
+++ b/Task/Functions/Instructions/al_introduceShield.m
@@ -92,7 +92,7 @@ while 1
     Screen('Flip', taskParam.display.window.onScreen, tUpdated + 1.6);
     
     % Terminate when subject presses enter
-    [keyIsDown, ~, keyCode ] = KbCheck;
+    [keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
     if keyIsDown
         if keyCode(taskParam.keys.enter)
             break    

--- a/Task/Functions/Instructions/introduceMisses.m
+++ b/Task/Functions/Instructions/introduceMisses.m
@@ -49,7 +49,7 @@ if (isequal(whichPractice, 'mainPractice') && abs(Data.predErr) >= 9) || (isequa
     t = GetSecs;
     Screen('Flip', taskParam.display.window.onScreen, t + 0.1);
     while 1
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
                 %screenIndex = screenIndex - 1;

--- a/Task/Functions/Instructions/oddballPractice.m
+++ b/Task/Functions/Instructions/oddballPractice.m
@@ -163,7 +163,7 @@ while 1
                 DrawFormattedText(taskParam.gParam.window.onScreen, taskParam.strings.txtPressEnter,'center', taskParam.gParam.screensize(4)*0.9, [255 255 255]);
                 Screen('DrawingFinished', taskParam.gParam.window.onScreen, 1);
                 Screen('Flip', taskParam.gParam.window.onScreen, t + 1.6);
-                [ keyIsDown, ~, keyCode ] = KbCheck;
+                [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
                 if keyIsDown
                     if keyCode(taskParam.keys.enter)
                         screenIndex = screenIndex + 1;

--- a/Task/Functions/Instructions/repeatShieldMiss.m
+++ b/Task/Functions/Instructions/repeatShieldMiss.m
@@ -42,7 +42,7 @@ if abs(taskData.predErr) <= 9
         Screen('DrawingFinished', taskParam.display.window.onScreen);
         t = GetSecs;
         Screen('Flip', taskParam.display.window.onScreen, t + 0.1);
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if keyCode(taskParam.keys.enter)
 %                screenIndex = screenIndex - 1 ;

--- a/Task/Functions/Instructions/reversalPractice.m
+++ b/Task/Functions/Instructions/reversalPractice.m
@@ -282,7 +282,7 @@ while 1
                     DrawFormattedText(taskParam.gParam.window.onScreen, taskParam.strings.txtPressEnter, 'center', taskParam.gParam.screensize(4)*0.9, [255 255 255]);
                     Screen('DrawingFinished', taskParam.gParam.window.onScreen, 1);
                     Screen('Flip', taskParam.gParam.window.onScreen, t + 1.6);
-                    [ keyIsDown, ~, keyCode ] = KbCheck;
+                    [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
                     if keyIsDown
                         if keyCode(taskParam.keys.enter)
                             screenIndex = screenIndex + 1;

--- a/Task/Functions/Instructions/taskScreen.m
+++ b/Task/Functions/Instructions/taskScreen.m
@@ -30,7 +30,7 @@ while 1
     Screen('DrawingFinished', taskParam.gParam.window.onScreen);
     t = GetSecs;
     Screen('Flip', taskParam.gParam.window.onScreen, t + 0.1);
-    [~, ~, keyCode] = KbCheck;
+    [~, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
     if find(keyCode) == taskParam.keys.enter
         screenIndex = screenIndex + 1;
         break

--- a/Task/Functions/al_bigScreen.m
+++ b/Task/Functions/al_bigScreen.m
@@ -73,7 +73,7 @@ while 1
     Screen('Flip', taskParam.display.window.onScreen, time + 0.1);
     
     % Check for response of participant to continue to next screen
-    [ ~, ~, keyCode] = KbCheck;
+    [ ~, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
     if keyCode(taskParam.keys.enter) && ~taskParam.unitTest && ~endOfTask
         % keyCode
         fw = 1;  % todo: this should be deleted

--- a/Task/Functions/al_conditionIndication.m
+++ b/Task/Functions/al_conditionIndication.m
@@ -21,7 +21,7 @@ Screen('Flip', taskParam.display.window.onScreen, t + 0.1);
 if ~taskParam.unitTest
     while 1
         
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown
             if find(keyCode) == taskParam.keys.enter
                 break

--- a/Task/Functions/al_controlPredSpotKeyboard.m
+++ b/Task/Functions/al_controlPredSpotKeyboard.m
@@ -27,7 +27,7 @@ breakLoop = false;
 
 % For unit test: simulate keyIsDown, keyCode, and record RT
 if ~taskParam.unitTest
-    [keyIsDown, ~, keyCode] = KbCheck;
+    [keyIsDown, ~, keyCode] = KbCheck ( taskParam.keys.kbDev );
 else
     WaitSecs(0.5);  % simulate RT = 0.5
     keyIsDown = 1;

--- a/Task/Functions/al_endTask.m
+++ b/Task/Functions/al_endTask.m
@@ -55,7 +55,7 @@ while 1
     
     % Check for keypress
     % ------------------
-    [ ~, ~, keyCode] = KbCheck;
+    [ ~, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
     if find(keyCode) == taskParam.keys.s & ~taskParam.unitTest
         break
     elseif taskParam.unitTest

--- a/Task/Functions/al_instrLoopTxt.m
+++ b/Task/Functions/al_instrLoopTxt.m
@@ -157,7 +157,7 @@ else
         
         Screen('Flip', taskParam.display.window.onScreen, t + 0.001);
         
-        [ keyIsDown, ~, keyCode ] = KbCheck;
+        [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
         
         if (keyIsDown && (isequal(button, 'arrow') && keyCode(taskParam.keys.enter))) || (isequal(button, 'space') &&  buttons(1) == 1)
             

--- a/Task/Functions/al_mouseLoop.m
+++ b/Task/Functions/al_mouseLoop.m
@@ -204,7 +204,7 @@ while 1
     end
 
     if breakKey == taskParam.keys.enter
-        [keyIsDown, ~, keyCode] = KbCheck;
+        [keyIsDown, ~, keyCode] = KbCheck( taskParam.keys.kbDev );
         if keyIsDown && keyCode(breakKey)
             break
         end

--- a/Task/Functions/al_practLoop.m
+++ b/Task/Functions/al_practLoop.m
@@ -140,7 +140,7 @@ for i = 1:trials
             Screen('Flip', taskParam.gParam.window.onScreen, t + 0.001);
             
             
-            [ keyIsDown, ~, keyCode ] = KbCheck;
+            [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
             
             if keyIsDown
                 if keyCode(taskParam.keys.rightKey)
@@ -305,7 +305,7 @@ for i = 1:trials
             
             Screen('Flip', taskParam.gParam.window.onScreen, t + 0.001);
             
-            [ keyIsDown, ~, keyCode ] = KbCheck;
+            [ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
             
             if buttons(1) == 1
                 

--- a/Task/Functions/al_screenIndex.m
+++ b/Task/Functions/al_screenIndex.m
@@ -10,7 +10,7 @@ function [screenIndex] = al_screenIndex(taskParam, screenIndex)
 
 
 % Check for keypress and update screen index
-[ keyIsDown, ~, keyCode ] = KbCheck;
+[ keyIsDown, ~, keyCode ] = KbCheck( taskParam.keys.kbDev );
 if keyIsDown
     if keyCode(taskParam.keys.enter)
         screenIndex = screenIndex + 1;

--- a/Task/TaskVersions/hamburg/RunHamburgVersion.m
+++ b/Task/TaskVersions/hamburg/RunHamburgVersion.m
@@ -90,7 +90,7 @@ confettiStd = 3;
 runIntro = true;
 
 % Choose if dialogue box should be shown
-askSubjInfo = true;
+askSubjInfo = false;
 
 % Determine blocks
 blockIndices = [1 50 100 150];
@@ -129,8 +129,11 @@ predSpotRad = 10;
 tickWidth = 1;
 
 % Key codes
-s = 40; % Für Hamburg KbDemo in Konsole laufen lassen und s drücken um keyCode zu bekommen: Hier eventuell anpassen
-enter = 37; % Hamburg: Hier bitte anpassen
+s = 22; % Für Hamburg KbDemo in Konsole laufen lassen und s drücken um keyCode zu bekommen: Hier eventuell anpassen
+enter = 40; % Hamburg: Hier bitte anpassen
+
+% Keyboard device number
+% kbDev = 19;
 
 % Run task in debug mode with smaller window
 debug = true;
@@ -148,7 +151,7 @@ hidePtbCursor = true;
 rewMag = 0.1;
 
 % Specify data directory
-dataDirectory = '~/Dropbox/AdaptiveLearning/DataDirectory';  % Hier bitte anpassen
+dataDirectory = '~/Projects/for/data/reward_pilot';  % Hier bitte anpassen
 
 % Confetti cannon image rectangle determining the size of the cannon
 imageRect = [0 00 60 200];
@@ -222,6 +225,11 @@ colors = al_colors();
 % ------------------------------------------
 
 keys = al_keys();
+if ~exist( 'kbDev' )
+  keys = al_kbdev( keys );
+else
+  keys.kbDev = kbDev;
+end
 keys.s = s;
 keys.enter = enter;
 

--- a/Task/TaskVersions/hamburg/al_HamburgInstructions.m
+++ b/Task/TaskVersions/hamburg/al_HamburgInstructions.m
@@ -1,5 +1,5 @@
 function al_HamburgInstructions(taskParam)
-%AL_HAMBURGINSTRUCTIONS This function runs the instructions for the
+%AL_HAMBURGINSTRUCTIONS This functio,,n runs the instructions for the
 % "Hamburg" version of the cannon task
 %
 %   Input


### PR DESCRIPTION
Hi Rasmus,
die Standardversion des Task  läuft mit den Veränderungen bei mir auf dem Macbook mit MacOS Ventura. Ich habe es (noch) noch auf Windows/Linux probiert.
Ich habe in der al_keys class etwas code für die Detektion des Keyboard Devices eingebaut.: wenn es eine DeviceNumber schon gibt , wird diese genommen, ansonsten werden alle Keyboards mit PsychHID detektiert. Wenn es mehrere gibt, werden diese gemerged (deviceNumber = -1), ansonsten wird das detektiert Keyboard verwendet.

Dann habe ich in allen Calls von KnCheck die kbDev Nummer aus der al_keys Class eingefügt.

Cheers,
Jan