### PR TITLE
Add codespell to prevent typos: config, workflow and some typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+# reference: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,*.pdf,.codespellrc,*.svg
+ignore-words-list = sie,startet,oder,ist,als,alle,linke,ende,deines,manuell,egal,lief,relativ,zar,vor,wont,deine

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@
 name: Codespell
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 permissions:
   contents: read
 jobs:

--- a/Task/Classes/al_display.m
+++ b/Task/Classes/al_display.m
@@ -14,7 +14,7 @@ classdef al_display
 
         % General
         screensize % screen size
-        screensizePart % witdh and height of screen
+        screensizePart % width and height of screen
         distance2screen % participant distance to screen in mm
         screenWidthInMM % for degrees visual angle
         window % psychtoolbox window

--- a/Task/Classes/al_eyeTracker.m
+++ b/Task/Classes/al_eyeTracker.m
@@ -46,7 +46,7 @@ classdef al_eyeTracker
         end
 
         function self = initializeEyeLink(self, taskParam, et_file_name_suffix)
-            % INITIALIZEEYELINK This function initialzes the eye-tracker
+            % INITIALIZEEYELINK This function initializes the eye-tracker
             %
             %   Input
             %       taskParam: Task-parameter-object instance

--- a/Task/Classes/al_gparam.m
+++ b/Task/Classes/al_gparam.m
@@ -23,7 +23,7 @@ classdef al_gparam
 
         shieldMu % mean shield size        
         shieldMin % minimum angular shield size        
-        shieldMax % maximium angular shield size         
+        shieldMax % maximum angular shield size         
                 
         trials % number of trials
         practTrials % number of practice trials

--- a/Task/Classes/al_strings.m
+++ b/Task/Classes/al_strings.m
@@ -26,7 +26,7 @@ classdef al_strings
         
         function self = al_strings()
             % AL_STRINGS This function creates a strings object
-            % of classs al_strings
+            % of class al_strings
             %
             %   The initial values correspond to useful defaults that
             %   are often used across tasks.

--- a/Task/Classes/al_taskDataMain.m
+++ b/Task/Classes/al_taskDataMain.m
@@ -716,7 +716,7 @@ classdef al_taskDataMain
         end
 
         function s = saveobj(self)
-            % SAVEOBJ This function tranlates data that we want to save
+            % SAVEOBJ This function translates data that we want to save
             % into a structure
             %
             %   Background:
@@ -849,7 +849,7 @@ classdef al_taskDataMain
             
             elseif isequal(self.taskType, 'infant')
 
-                % Todo carefull check what we need
+                % Todo careful check what we need
                 % when everything is implemented
                 
                 s.group = self.group;

--- a/Task/Classes/al_trialflow.m
+++ b/Task/Classes/al_trialflow.m
@@ -71,7 +71,7 @@ classdef al_trialflow
         
         % Whether or not tickmarks for current trial are used
         currentTickmarks
-            % show: standard tick makrs
+            % show: standard tick marks
             % workingMemory: 5 last outcomes
             % hide: no tick marks
         
@@ -141,7 +141,7 @@ classdef al_trialflow
         
         function self = al_trialflow()
             %AL_TRIALFLOW This function creates a trialflow object
-            % of classs al_trialflow
+            % of class al_trialflow
             %
             %   The initial values correspond to useful defaults that
             %   are often used across tasks.

--- a/Task/Functions/al_baselineArousal.m
+++ b/Task/Functions/al_baselineArousal.m
@@ -37,7 +37,7 @@ for i = 1:size(arousalColors,1)
         Eyelink('message', 'TRIALID %d', i);
     end
 
-    % Only send trigger on first interation
+    % Only send trigger on first iteration
     firstIteration = true;
 
     % Beginning of current color

--- a/Task/Functions/al_controlPredSpotKeyboard.m
+++ b/Task/Functions/al_controlPredSpotKeyboard.m
@@ -12,7 +12,7 @@ function [breakLoop, taskParam, taskData, keyCode] = al_controlPredSpotKeyboard(
 %       disableResponseThreshold: Optionally activate response time
 %                                 limit (if additionally specified in trialflow)
 %
-%   Ouptut
+%   Output
 %       breakLoop: Index response loop should be terminated
 %       taskParam: Task-parameter-object instance
 %       taskData: Task-data-object instance
@@ -98,7 +98,7 @@ end
 % Here, we separated both conditions for initRT and prediction control
 % to make sure that both would be completed even if button press was
 % extremely fast (which practically does not happen bc button press is
-% longer than one cyle in while loop).
+% longer than one cycle in while loop).
 
 % Second case: When other keys are pressed before space, update orange spot until space
 % is pressed

--- a/Task/Functions/al_drawCircle.m
+++ b/Task/Functions/al_drawCircle.m
@@ -19,7 +19,7 @@ zero = taskParam.display.zero;
 % Generate circle
 Screen(taskParam.display.window.onScreen, 'FrameOval', taskParam.colors.circleCol, [zero(1) - rotRad, zero(2) - rotRad, zero(1) + rotRad, zero(2) + rotRad], [], circleWidth, []);
 
-% Mannually darawing two lines to check circle properties to compute number
+% Manually darawing two lines to check circle properties to compute number
 % of pixels for isoluminant background
 % rotRad = 140;
 % Screen(taskParam.display.window.onScreen, 'FrameOval', [0 0 0], [zero(1) - rotRad, zero(2) - rotRad, zero(1) + rotRad, zero(2) + rotRad], [], 1, []);

--- a/Task/Functions/al_keyboardLoop.m
+++ b/Task/Functions/al_keyboardLoop.m
@@ -12,7 +12,7 @@ function [taskData, taskParam] = al_keyboardLoop(taskParam, taskData, trial, sta
 %       disableResponseThreshold: Optionally activate response time
 %                                 limit (if additionally specified in trialflow)
 %
-%   Ouptut
+%   Output
 %       taskData: Task-parameter-object instance
 %       taskParam: Task-data-object instance
 

--- a/Task/Functions/al_lineAndBack.m
+++ b/Task/Functions/al_lineAndBack.m
@@ -1,5 +1,5 @@
 function al_lineAndBack(taskParam)
-%AL_LINEANDBACK This function draws the background for intructions in the cannon task
+%AL_LINEANDBACK This function draws the background for instructions in the cannon task
 %
 %   Input
 %       taskParam: Task-parameter-object instance

--- a/Task/Functions/al_minMaxNormalization.m
+++ b/Task/Functions/al_minMaxNormalization.m
@@ -1,5 +1,5 @@
 function normalizedCoordinate = al_minMaxNormalization(currMouseCoord, minCoord, maxCoord)
-%AL_MINMAXNORMALIZATION This function perfoms min-max normalization for the
+%AL_MINMAXNORMALIZATION This function performs min-max normalization for the
 %joystick at the Donner MEG lab at UKE
 %
 %   Input

--- a/Task/Functions/al_sendTrigger.m
+++ b/Task/Functions/al_sendTrigger.m
@@ -8,7 +8,7 @@ function triggerID = al_sendTrigger(taskParam, taskData, condition, trial, Teven
 %       trial: Current trial
 %       Tevent: Event type that gets triggered
 %
-%   Ouptut
+%   Output
 %       triggerID: Current trigger
 
 

--- a/Task/Functions/al_stressSlider.m
+++ b/Task/Functions/al_stressSlider.m
@@ -25,7 +25,7 @@ smallTextSize = taskParam.strings.headerSize;
 scaleLengthPix = taskParam.display.screensize(4) / 1.5;
 scaleHLengthPix = scaleLengthPix / 2;
 
-% Coordiantes of the scale left and right ends
+% Coordinates of the scale left and right ends
 leftEnd = [taskParam.display.zero(1) - scaleHLengthPix taskParam.display.zero(2)];
 rightEnd = [taskParam.display.zero(1) + scaleHLengthPix taskParam.display.zero(2)];
 scaleLineCoords = [leftEnd' rightEnd'];
@@ -54,7 +54,7 @@ for i = 1:numScalePoints
     [~, ~, numBoundsAll(i, :)] = DrawFormattedText(taskParam.display.window.onScreen, num2str(i), 0, 0, taskParam.colors.white);
 end
 
-% Width and height of the scale number text bounding boxs
+% Width and height of the scale number text bounding boxes
 numWidths = numBoundsAll(:, 3)';
 halfNumWidths = numWidths / 2;
 numHeights = [range([numBoundsAll(:, 2) numBoundsAll(:, 4)], 2)]';
@@ -64,7 +64,7 @@ halfNumHeights = numHeights / 2;
 dim = 40;
 hDim = dim / 2;
 
-% The numbers are aligned to be directly under the relevent button (tops of
+% The numbers are aligned to be directly under the relevant button (tops of
 % their bounding boxes "numShiftDownPix" below the button y coordinate, and
 % aligned laterally such that the centre of the text bounding boxes aligned
 % with the x coordinate of the button

--- a/Task/Functions/al_tickMark.m
+++ b/Task/Functions/al_tickMark.m
@@ -7,7 +7,7 @@ function [tickLength, col] = al_tickMark(taskParam, parameter, type)
 %       type: Tick-mark type
 %
 %   Output
-%       tickLength: Length of tick mark to compute backgound RGB
+%       tickLength: Length of tick mark to compute background RGB
 %       col: Color to compute background RGB
 %
 % Todo: integrate in circle

--- a/Task/Functions/catstruct.m
+++ b/Task/Functions/catstruct.m
@@ -62,7 +62,7 @@ function A = catstruct(varargin)
 %                  (thanks to Tor Inge Birkenes).
 %                  Rephrased the help section as well.
 %   4.0 (dec 2013) fixed problem with unique due to version differences in
-%                  ML. Unique(...,'last') is no longer the deafult.
+%                  ML. Unique(...,'last') is no longer the default.
 %                  (thanks to Isabel P)
 
 %error(nargchk(1,Inf,nargin)) ;

--- a/Task/Functions/deg2rad.m
+++ b/Task/Functions/deg2rad.m
@@ -5,7 +5,7 @@ function rad = deg2rad(deg)
 % Keith Brady 18-08-2010
 %
 % Conversion function from Degrees to Radian.
-% an alterative form to the functions by Richard Medlock renamed as
+% an alternative form to the functions by Richard Medlock renamed as
 % suggested in the blog article 
 %
 % http://blogs.mathworks.com/pick/2009/11/27/degrees-and-radians/

--- a/Task/TaskVersions/Other/MagdeburgFMRI/al_MagdeburgFMRIInstructions.m
+++ b/Task/TaskVersions/Other/MagdeburgFMRI/al_MagdeburgFMRIInstructions.m
@@ -143,7 +143,7 @@ taskData = load('visCannonPracticeMagdeburgFMRI.mat');
 taskData = taskData.taskData;
 taskData.initialTendency = nan(length(taskData.ID), 1);
 
-% Reset roation angle to starting location
+% Reset rotation angle to starting location
 taskParam.circle.rotAngle = 0;
 
 % Run task

--- a/Task/TaskVersions/Other/dresden/OutputTest.m
+++ b/Task/TaskVersions/Other/dresden/OutputTest.m
@@ -912,7 +912,7 @@ classdef OutputTest < matlab.unittest.TestCase
 %             % Set number of trials of control task
 %             controlTrials = 4;  % this is the new control version that we added to control for differences between groups
 %             
-%             % Number of practice trials - note that in "reversal" version this is muliplied by 2
+%             % Number of practice trials - note that in "reversal" version this is multiplied by 2
 %             practTrials = 2;
 %             
 %             % Number of trials to introduce the shield in the cover story
@@ -1012,7 +1012,7 @@ classdef OutputTest < matlab.unittest.TestCase
 %             timingParam = al_timing(timing_init);
 %             
 %             % ---------------------------------------------
-%             % Create object instance with srings to display
+%             % Create object instance with strings to display
 %             % ---------------------------------------------
 %             
 %             strings_init = al_stringsinit();

--- a/Task/TaskVersions/Other/dresden/RunDresdenVersion.m
+++ b/Task/TaskVersions/Other/dresden/RunDresdenVersion.m
@@ -94,7 +94,7 @@ practiceTrialCriterionNTrials = 5;
 practiceTrialCriterionEstErr = 9;
 
 % Rotation radius
-rotationRad = 200; % this value should be differen on other computers
+rotationRad = 200; % this value should be different on other computers
 
 % Tickmark width
 tickWidth = 1;
@@ -205,7 +205,7 @@ timingParam.rewardLength = 1.0;
 timingParam.fixedITI = 0.9;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/Other/dresden/al_dresdenInstructions.m
+++ b/Task/TaskVersions/Other/dresden/al_dresdenInstructions.m
@@ -368,7 +368,7 @@ while 1
     end
 end
 
-% Confim that cannon ball was missed
+% Confirm that cannon ball was missed
 win = true;
 if isequal(whichPractice, 'main') || isequal(whichPractice, 'followCannon')
     txt = 'Weil Sie die Kanonenkugel verpasst haben, hätten Sie nichts verdient.';
@@ -520,7 +520,7 @@ al_bigScreen(taskParam, header, txt, feedback);
 practData = load('CP_Noise.mat');
 taskData = practData.practData;
 
-% Reset roation angle to starting location
+% Reset rotation angle to starting location
 taskParam.circle.rotAngle = 0;
 
 % Practice session

--- a/Task/TaskVersions/Other/sleep/RunSleepVersion.m
+++ b/Task/TaskVersions/Other/sleep/RunSleepVersion.m
@@ -15,7 +15,7 @@ function [dataNoPush, dataPush] = RunSleepVersion(runUnitTest, cBal, day)
 %       This function runs the sleep-study version of the cannon task.
 %       Subjects are sleep deprived and perform the task within
 %       a larger test battery. The version is shorter that usual
-%       and focuses on the most essential intructions.
+%       and focuses on the most essential instructions.
 %
 %   Testing
 %       To run the integration test, run "al_sleepIntegrationTest"
@@ -217,7 +217,7 @@ keys.enter = enter;
 timingParam = al_timing();
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 timingParam.jitterFixCrossOutcome = 0; % we did not use jitter here

--- a/Task/TaskVersions/Other/sleep/al_sleepInstructions.m
+++ b/Task/TaskVersions/Other/sleep/al_sleepInstructions.m
@@ -152,7 +152,7 @@ if testDay == 1
     taskData = load('visCannonPracticeSleep.mat');
     taskData = taskData.taskData;
 
-    % Reset roation angle to starting location
+    % Reset rotation angle to starting location
     taskParam.circle.rotAngle = 0;
 
     % Run task

--- a/Task/TaskVersions/ResearchUnit/AsymmetricReward/RunAsymRewardVersion.m
+++ b/Task/TaskVersions/ResearchUnit/AsymmetricReward/RunAsymRewardVersion.m
@@ -239,7 +239,7 @@ timingParam.rewardLength = 1.5;
 % timingParam.fixCrossOutcome = 0.5;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/ResearchUnit/AsymmetricReward/al_asymRewardInstructions.m
+++ b/Task/TaskVersions/ResearchUnit/AsymmetricReward/al_asymRewardInstructions.m
@@ -132,7 +132,7 @@ if testDay == 1
     taskData = taskData.taskData;
     taskParam.trialflow.exp = 'practVis';
 
-    % Reset roation angle to starting location
+    % Reset rotation angle to starting location
     taskParam.circle.rotAngle = 0;
 
     % Run task

--- a/Task/TaskVersions/ResearchUnit/EEG/RunConfettiEEGVersion.m
+++ b/Task/TaskVersions/ResearchUnit/EEG/RunConfettiEEGVersion.m
@@ -118,7 +118,7 @@ predSpotCircleTolerance = config.predSpotCircleTolerance;
 % customInstructions = config.customInstructions;
 % instructionText = config.instructionText;
 
-% More general paramters
+% More general parameters
 % ----------------------
 
 % Risk parameter: Precision of confetti average
@@ -291,7 +291,7 @@ timingParam.jitterShield = 0.0; % 0.15; % we use this one for the reward phase
 timingParam.jitterITI = 0.2;  
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 
@@ -523,7 +523,7 @@ totWin = dataMonetary.accPerf(end);
 % -----------
 
 header = 'Ende des Versuchs!';
-txt = sprintf('Vielen Dank für Deine Teilnahme!\n\n\nDu hast insgesamt %.2f Euro gewonnen!', totWin);
+txt = sprintf('Vielen Dank fï¿½r Deine Teilnahme!\n\n\nDu hast insgesamt %.2f Euro gewonnen!', totWin);
 feedback = true; % indicate that this is the instruction mode
 al_bigScreen(taskParam, header, txt, feedback, true);
 

--- a/Task/TaskVersions/ResearchUnit/EEG/al_confettiEEGConfigExample.m
+++ b/Task/TaskVersions/ResearchUnit/EEG/al_confettiEEGConfigExample.m
@@ -4,7 +4,7 @@
 % function that runs the task.
 %
 % It is recommended that you create your own script with the local 
-% parameter settings so that you can re-use your settings.
+% parameter settings so that you can reuse your settings.
 
 % Create config structure
 config = struct();

--- a/Task/TaskVersions/ResearchUnit/EEG/al_confettiEEGLoop.m
+++ b/Task/TaskVersions/ResearchUnit/EEG/al_confettiEEGLoop.m
@@ -3,7 +3,7 @@ function taskData = al_confettiEEGLoop(taskParam, condition, taskData, trial)
 %
 %   Input
 %       taskParam: Task-parameter-object instance
-%       condtion: Condition type
+%       condition: Condition type
 %       taskData: Task-data-object instance
 %       trial: Number of trials
 %

--- a/Task/TaskVersions/ResearchUnit/Infant/RunInfantVersion.m
+++ b/Task/TaskVersions/ResearchUnit/Infant/RunInfantVersion.m
@@ -215,7 +215,7 @@ timingParam.staticOutcome = 1.0;
 timingParam.movingOutcome = 1.0;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/ResearchUnit/Infant/al_infantConfigExample.m
+++ b/Task/TaskVersions/ResearchUnit/Infant/al_infantConfigExample.m
@@ -4,7 +4,7 @@
 % function that runs the task.
 %
 % It is recommended that you create your own script with the local 
-% parameter settings so that you can re-use your settings.
+% parameter settings so that you can reuse your settings.
 
 % Create config structure
 config = struct();

--- a/Task/TaskVersions/ResearchUnit/Infant/al_infantLoop.m
+++ b/Task/TaskVersions/ResearchUnit/Infant/al_infantLoop.m
@@ -6,7 +6,7 @@ function taskData = al_infantLoop(taskParam, condition, concentration, trial, my
 %
 %   Input
 %       taskParam: Task-parameter-object instance
-%       condtion: Condition type
+%       condition: Condition type
 %       concentration: Noise in outcomes
 %       trial: Number of trials
 %       myTobii: Tobii eye-tracker object
@@ -109,10 +109,10 @@ while 1
     % Todo: if not used anymore, get rid of this in timingParam as well
     % timestampOutcomeMovementOffset = timestampOutcomeStaticOffset + taskParam.timingParam.movingOutcome;
 
-    % Initilalize variable controlling movement frequency
+    % Initialize variable controlling movement frequency
     duckLastMovement = GetSecs() - taskParam.gParam.duckMovementFrequency;
 
-    % Initilalize variable controlling gaze sampling
+    % Initialize variable controlling gaze sampling
     lastGazeSample = GetSecs() - 1/gazeSamplingRate;
 
     % Generate change point
@@ -351,7 +351,7 @@ while 1
             lastGazeSample = GetSecs();
            
             % This if statement is just for debugging
-            % When full screen with eye-tracker, always chech if samples in
+            % When full screen with eye-tracker, always check if samples in
             % AOI
             if isnan(myTobii) && (gazeX > taskParam.display.screensizePart(1)) == false && (gazeY > taskParam.display.screensizePart(2)) == false
             

--- a/Task/TaskVersions/ResearchUnit/Leipzig/RunLeipzigVersion.m
+++ b/Task/TaskVersions/ResearchUnit/Leipzig/RunLeipzigVersion.m
@@ -229,7 +229,7 @@ timingParam = al_timing();
 timingParam.cannonBallAnimation = 1.5;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/ResearchUnit/Leipzig/al_LeipzigInstructions.m
+++ b/Task/TaskVersions/ResearchUnit/Leipzig/al_LeipzigInstructions.m
@@ -164,7 +164,7 @@ taskData = taskData.taskData;
 taskParam.trialflow.exp = 'practVis';
 taskData.initialTendency = nan(length(taskData.ID), 1);
 
-% Reset roation angle to starting location
+% Reset rotation angle to starting location
 taskParam.circle.rotAngle = 0;
 
 % Run task

--- a/Task/TaskVersions/ResearchUnit/Leipzig/al_LeipzigLoop.m
+++ b/Task/TaskVersions/ResearchUnit/Leipzig/al_LeipzigLoop.m
@@ -4,7 +4,7 @@ function taskData = al_LeipzigLoop(taskParam, condition, taskData, trial)
 %
 %   Input
 %       taskParam: Task-parameter-object instance
-%       condtion: Condition type
+%       condition: Condition type
 %       taskData: Task-data-object instance
 %       trial: Number of trials
 %
@@ -78,7 +78,7 @@ for i = 1:trial
     %------------------------------
 
     % Send fixation cross 1 trigger
-    % todo: this should be done in mouse loop, like I did fo keyboardLoop
+    % todo: this should be done in mouse loop, like I did for keyboardLoop
     taskData.timestampPrediction(i,:) = GetSecs - taskParam.timingParam.ref;
 
     % Deviation from cannon (estimation error) to compute performance

--- a/Task/TaskVersions/ResearchUnit/Leipzig/al_indicateHelicopterNoise.m
+++ b/Task/TaskVersions/ResearchUnit/Leipzig/al_indicateHelicopterNoise.m
@@ -1,6 +1,6 @@
 function al_indicateHelicopterNoise(taskParam, noiseCondition)
 % AL_INDICATENOISE This function indicates the noise
-% condition in the Leipzig helicopter verion
+% condition in the Leipzig helicopter version
 %
 %   Input:
 %       taskParam: Task-parameter-object instance

--- a/Task/TaskVersions/ResearchUnit/VWM/RunVarianceWorkingMemoryVersion.m
+++ b/Task/TaskVersions/ResearchUnit/VWM/RunVarianceWorkingMemoryVersion.m
@@ -259,7 +259,7 @@ timingParam = al_timing();
 timingParam.cannonBallAnimation = 1.5;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/ResearchUnit/VWM/al_VWMInstructions.m
+++ b/Task/TaskVersions/ResearchUnit/VWM/al_VWMInstructions.m
@@ -168,7 +168,7 @@ if testDay == 1
     taskData = taskData.taskData;
     taskData.initialTendency = nan(length(taskData.ID), 1);
 
-    % Reset roation angle to starting location
+    % Reset rotation angle to starting location
     taskParam.circle.rotAngle = 0;
 
     % Run task

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/RunCommonConfettiVersion.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/RunCommonConfettiVersion.m
@@ -345,7 +345,7 @@ timingParam.jitterShield = 0.15; % 0.6;
 timingParam.jitterITI = 0.5;
 
 % This is a reference timestamp at the start of the experiment.
-% This is not equal to the first trial or so. So be carful when using
+% This is not equal to the first trial or so. So be careful when using
 % EEG or pupillometry and make sure the reference is specified as desired.
 timingParam.ref = GetSecs();
 

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_MRILoop.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_MRILoop.m
@@ -254,7 +254,7 @@ for i = 1:trial
                     fprintf('Fixation-cross 1 duration: %.5f\n', taskData.timestampOutcome(i) - taskData.timestampFixCross1(i))
                 end
 
-                % ... then re-use dots for rest of the trial
+                % ... then reuse dots for rest of the trial
             else
                 regenerateParticles = false;
                 al_confettiOutcome(taskParam, taskData, i, regenerateParticles);

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConditions.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConditions.m
@@ -151,7 +151,7 @@ if taskParam.gParam.baselineArousal
     feedback = false; % indicate that this is the instruction mode
     al_bigScreen(taskParam, header, txt, feedback, true);
 
-    % Meaure baseline arousal
+    % Measure baseline arousal
     al_baselineArousal(taskParam, '_a2')
 
 end

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConditionsFMRI.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConditionsFMRI.m
@@ -101,7 +101,7 @@ else
         feedback = false; % indicate that this is the instruction mode
         al_bigScreen(taskParam, header, txt, feedback);
 
-        % Meaure baseline arousal
+        % Measure baseline arousal
         al_baselineArousal(taskParam)
 
     end
@@ -206,7 +206,7 @@ else
         feedback = false; % indicate that this is the instruction mode
         al_bigScreen(taskParam, header, txt, feedback);
 
-        % Meaure baseline arousal
+        % Measure baseline arousal
         al_baselineArousal(taskParam)
 
     end

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConfigExample.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiConfigExample.m
@@ -4,7 +4,7 @@
 % function that runs the task.
 %
 % It is recommended that you create your own script with the local 
-% parameter settings so that you can re-use your settings.
+% parameter settings so that you can reuse your settings.
 
 % Create config structure
 config = struct();

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiInstructions.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiInstructions.m
@@ -225,7 +225,7 @@ taskParam.trialflow.exp = 'practVis';
 taskParam.trialflow.saveData = 'true';
 taskParam.trialflow.shieldAppearance = 'full';
 
-% Reset roation angle to starting location
+% Reset rotation angle to starting location
 taskParam.circle.rotAngle = 0;
 
 % Update unit test predictions

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiInstructionsDefaultText.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_commonConfettiInstructionsDefaultText.m
@@ -1,6 +1,6 @@
 classdef al_commonConfettiInstructionsDefaultText
     %AL_COMMONCONFETTIINSTRUCTIONSDEFAULTTEXT This class-definition file
-    % specifiec the properties of the instruction text.
+    % specifies the properties of the instruction text.
     %
     % The advantage of this kind of text file is that most text is in one
     % place and a local file can replace (specified in the config file) the

--- a/Task/TaskVersions/ResearchUnit/commonConfetti/al_passiveViewingConfigExample.m
+++ b/Task/TaskVersions/ResearchUnit/commonConfetti/al_passiveViewingConfigExample.m
@@ -4,7 +4,7 @@
 % function that runs the task.
 %
 % It is recommended that you create your own script with the local 
-% parameter settings so that you can re-use your settings.
+% parameter settings so that you can reuse your settings.
 
 
 % todo: optionally no noise conditions and only random outcomes with haz=1


### PR DESCRIPTION
Had to add a few German words to `ignore-words-list` in `.codespellrc`, most of them in the instructions.

```
ignore-words-list = sie,startet,oder,ist,als,alle,linke,ende,deines,manuell,egal,lief,relativ,zar,vor,wont,deine
```

As far as I know, codespell can only handle English. Maybe in the future words from `ignore-words-list` can gradually be reduced to avoid false negatives.

I hope I caught all typos correctly. Let me know if anything needs adjustment.